### PR TITLE
feat: 레이아웃 패딩 추가 및 모바일 개발을 위한 배경색 추가

### DIFF
--- a/src/domain/_common/layouts/DefaultMobileLayout/index.tsx
+++ b/src/domain/_common/layouts/DefaultMobileLayout/index.tsx
@@ -4,7 +4,7 @@ export default function DefaultMobileLayout() {
   return (
     <main
       className={
-        'm-auto grid min-h-screen w-full max-w-full grid-rows-header-footer bg-grey-background text-grey-300 sm:max-w-lg'
+        'm-auto grid min-h-screen w-full max-w-full grid-rows-header-footer bg-white text-grey-300 sm:max-w-lg px-[27px] py-6'
       }
     >
       <Outlet />

--- a/src/global.css
+++ b/src/global.css
@@ -15,5 +15,6 @@
     min-width: 350px;
     position: relative;
     height: 100dvh;
+    background: #F6F6F6;
   }
 }


### PR DESCRIPTION
## 🐶 개요
레이아웃 정의에 맞춰서 x y축 패딩을 추가했습니다.
추가적으로 모바일 개발 시, 경계가 잘 보이도록 회색 배경을 추가해서 경계를 보이게 했어요.

## 🐱 설명
x, y축은 정의에 따라 24px, 27px로 정의했고,
기본 레이아웃 배경은 white,
그리고 경계를 위한 body의 bg는 회색으로 두었습니다.

## 🏞️ 스크린샷
![image](https://github.com/0ne6yte/life-4-cut-frontend/assets/78866590/95a7d97d-1594-4c26-a1fd-8e7150cf395e)


## 🤔 참고사항
